### PR TITLE
feat: add shell completion command for bash/zsh/fish/powershell

### DIFF
--- a/internal/adapters/cli/commands/completion.go
+++ b/internal/adapters/cli/commands/completion.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// newCompletionCommand creates the completion subcommand for shell completions.
+func newCompletionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion script",
+		Long: `Generate shell completion script for reqflow.
+
+Install completions by adding the output to your shell profile:
+
+  reqflow completion bash > /etc/bash_completion.d/reqflow
+  reqflow completion zsh > "${fpath[1]}/_reqflow"
+  reqflow completion fish > ~/.config/fish/completions/reqflow.fish
+  reqflow completion powershell > reqflow.ps1`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/adapters/cli/commands/root.go
+++ b/internal/adapters/cli/commands/root.go
@@ -32,5 +32,8 @@ func NewRootCommand(a *app.App) *cobra.Command {
 	root.AddCommand(newPatchCommand(a))
 	root.AddCommand(newDeleteCommand(a))
 
+	// Shell completion.
+	root.AddCommand(newCompletionCommand())
+
 	return root
 }


### PR DESCRIPTION
## Summary
Wire up Cobra's built-in completion generation via `reqflow completion <shell>`.

## Changes
- Add `completion.go` with `newCompletionCommand()` supporting bash, zsh, fish, powershell
- Register in `root.go` via `root.AddCommand(newCompletionCommand())`

## Usage
```bash
reqflow completion bash > /etc/bash_completion.d/reqflow
reqflow completion zsh > "${fpath[1]}/_reqflow"
reqflow completion fish > ~/.config/fish/completions/reqflow.fish
reqflow completion powershell > reqflow.ps1
```

## Test plan
- [ ] `reqflow completion bash` outputs valid bash script
- [ ] `reqflow completion zsh` outputs valid zsh script
- [ ] `reqflow completion fish` outputs valid fish script
- [ ] `reqflow completion powershell` outputs valid PS1 script
- [ ] Invalid shell name → error

Closes #5